### PR TITLE
Attempt to fix a11y issue by adding tabindex to content area

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -13,6 +13,7 @@ const Container = styled.div<{ background: string }>`
   padding: 5rem;
   display: flex;
   transition: background 0.4s;
+  position: relative;
 
   ${BREAKPOINTS.MOBILE} {
     padding: 0.5rem;
@@ -58,9 +59,9 @@ function Inner({ children }: InnerProps) {
   const context = useContext(RoutingContext);
   return (
     <Container background={context.currentGridColor}>
-      <Stage id="stage" invert={context.currentGrid === "blm"}>
+      <Stage id="stage" invert={context.currentGrid === "blm"} tabIndex={0}>
         <Navigation />
-        <Content>{children}</Content>
+        <Content id="content">{children}</Content>
       </Stage>
     </Container>
   );


### PR DESCRIPTION
This attempts to fix #1, even though it's still not ideal, the user has to actively focus the content area. Tried to get the same design implemented while using the body as main scroll area, but no luck 😞